### PR TITLE
Complete overhaul, get rid of `notebook` dependency

### DIFF
--- a/ipynbname/__init__.py
+++ b/ipynbname/__init__.py
@@ -1,15 +1,36 @@
-from notebook import notebookapp
-import urllib, json, os, ipykernel, ntpath
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePath
+from typing import Generator, Tuple, Union
+
+import ipykernel
+from jupyter_core.paths import jupyter_runtime_dir
+from traitlets.config import MultipleInstanceError
+
 
 FILE_ERROR = "Can't identify the notebook {}."
-CONN_ERROR = "Unable to access server;\n \
-            + ipynbname requires either no security or token based security."
+CONN_ERROR = "Unable to access server;\n" \
+           + "ipynbname requires either no security or token based security."
 
-def _get_kernel_id():
+
+def _list_maybe_running_servers(runtime_dir=None) -> Generator[dict]:
+    """Iterate over the server info files of running notebook servers.
+    """
+    if runtime_dir is None:
+        runtime_dir = jupyter_runtime_dir()
+    runtime_dir = Path(runtime_dir)
+
+    if runtime_dir.is_dir():
+        for file_name in runtime_dir.glob('nbserver-*.json'):
+            yield json.loads(file_name.read_bytes())
+
+
+def _get_kernel_id() -> str:
     """ Returns the kernel ID of the ipykernel.
     """
-    connection_file = os.path.basename(ipykernel.get_connection_file())
-    kernel_id = connection_file.split('-', 1)[1].split('.')[0]
+    connection_file = Path(ipykernel.get_connection_file()).stem
+    kernel_id = connection_file.split('-', 1)[1]
     return kernel_id
 
 
@@ -25,51 +46,44 @@ def _get_sessions(srv):
         if token:
             qry_str = f"?token={token}"
         url = f"{srv['url']}api/sessions{qry_str}"
-        req = urllib.request.urlopen(url)
-        return json.load(req)
-    except:
+        with urllib.request.urlopen(url) as req:
+            return json.load(req)
+    except Exception:
         raise urllib.error.HTTPError(CONN_ERROR)
 
 
-def _get_nb_path(sess, kernel_id):
-    """ Given a session and kernel ID, returns the notebook path for the
-        session, or None if there is no notebook for the session.    
-    """
-    if sess['kernel']['id'] == kernel_id:
-        return sess['notebook']['path']
-    return None
-
-
-def name():
-    """ Returns the short name of the notebook w/o the .ipynb extension,
-        or raises a FileNotFoundError exception if it cannot be determined.     
-    """
-    kernel_id = _get_kernel_id()
-    for srv in notebookapp.list_running_servers():
+def _find_nb_path() -> Union[Tuple[dict, PurePath], Tuple[None, None]]:
+    try:
+        kernel_id = _get_kernel_id()
+    except (MultipleInstanceError, RuntimeError):
+        return None, None  # Could not determine
+    for srv in _list_maybe_running_servers():
         try:
             sessions = _get_sessions(srv)
             for sess in sessions:
-                nb_path = _get_nb_path(sess, kernel_id)
-                if nb_path:
-                    return ntpath.basename(nb_path).replace('.ipynb', '')
-        except:
+                if sess['kernel']['id'] == kernel_id:
+                    return srv, PurePath(sess['notebook']['path'])
+        except Exception:
             pass  # There may be stale entries in the runtime directory
+    return None, None
+
+
+def name() -> str:
+    """ Returns the short name of the notebook w/o the .ipynb extension,
+        or raises a FileNotFoundError exception if it cannot be determined.
+    """
+    _, path = _find_nb_path()
+    if path:
+        return path.stem
     raise FileNotFoundError(FILE_ERROR.format('name'))
 
 
-def path():
+def path() -> Path:
     """ Returns the absolute path of the notebook,
         or raises a FileNotFoundError exception if it cannot be determined.
     """
-    kernel_id = _get_kernel_id()
-    for srv in notebookapp.list_running_servers():
-        try:
-            sessions = _get_sessions(srv)
-            for sess in sessions:
-                nb_path = _get_nb_path(sess, kernel_id)
-                if nb_path:
-                    return os.path.join(srv['notebook_dir'], nb_path)
-        except:
-            pass  # There may be stale entries in the runtime directory
+    srv, path = _find_nb_path()
+    if srv and path:
+        return Path(srv['notebook_dir']) / path
     raise FileNotFoundError(FILE_ERROR.format('path'))
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 import setuptools
+from pathlib import Path
 
-# read the contents of your README file
-from os import path
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), 'r') as f:
-    long_description = f.read()
+here = Path(__file__).parent
+long_description = (here / 'README.md').read_text()
 
 setuptools.setup(
     name='ipynbname',
@@ -19,7 +17,7 @@ setuptools.setup(
     url='https://github.com/msm1089/ipynbname',
     packages=setuptools.find_packages(),
     package_data={},
-    install_requires=[],
+    install_requires=['ipykernel'],
     python_requires='>=3.4, <4',
     classifiers=[
         'Operating System :: OS Independent',


### PR DESCRIPTION
The `notebook` package is unnecessary to get a list of maybe running kernels.

It now only depends on `ipykernel` (and its dependencies), allowing us to not have `notebook` installed.

I also made it raise `FileNotFoundError` if `_get_kernel_id` fails.