### PR TITLE
Use more universal session["path"]

### DIFF
--- a/ipynbname/__init__.py
+++ b/ipynbname/__init__.py
@@ -80,7 +80,7 @@ def _find_nb_path() -> Union[Tuple[dict, PurePath], Tuple[None, None]]:
             sessions = _get_sessions(srv)
             for sess in sessions:
                 if sess['kernel']['id'] == kernel_id:
-                    return srv, PurePath(sess['notebook']['path'] if "notebook" in sess else sess['path'])
+                    return srv, PurePath(sess['path'])
         except Exception:
             pass  # There may be stale entries in the runtime directory
     return None, None

--- a/ipynbname/__init__.py
+++ b/ipynbname/__init__.py
@@ -80,7 +80,7 @@ def _find_nb_path() -> Union[Tuple[dict, PurePath], Tuple[None, None]]:
             sessions = _get_sessions(srv)
             for sess in sessions:
                 if sess['kernel']['id'] == kernel_id:
-                    return srv, PurePath(sess['notebook']['path'])
+                    return srv, PurePath(sess['notebook']['path'] if "notebook" in sess else sess['path'])
         except Exception:
             pass  # There may be stale entries in the runtime directory
     return None, None


### PR DESCRIPTION
Since a while back the path for all sessions is stored in a key `path`, regardless of file type. I couldn't find the exact commit reference but you can see the changes to the API here: https://github.com/jupyter-server/jupyter_server/commit/8c6257bea58ba4638437a7d359f3482403222483

Although `.ipynb` files still have a `sess["notebook"]["path"]` key, a simple `.py` file opened _as notebook_ does not, only `sess["path"]`, and i think it would be nice for this package to return those file paths too.