### PR TITLE
Remove python upper-bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={},
     install_requires=['ipykernel'],
-    python_requires='>=3.4, <4',
+    python_requires='>=3.4',
     classifiers=[
         'Operating System :: OS Independent',
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This is not needed, as Python doesn't follow SemVer, and breaks users using `ipynbname` with other package managers, like `poetry`. See also https://twitter.com/codewithanthony/status/1362181541191766017

Cheers!