### PR TITLE
Fix bug in _get_sessions (JupyterHub)

### DIFF
--- a/ipynbname/__init__.py
+++ b/ipynbname/__init__.py
@@ -58,10 +58,9 @@ def _get_sessions(srv):
     try:
         qry_str = ""
         token = srv['token']
-        if token:
-            qry_str = f"?token={token}"
         if not token and "JUPYTERHUB_API_TOKEN" in os.environ:
             token = os.environ["JUPYTERHUB_API_TOKEN"]
+        qry_str = f"?token={token}" if token else ""
         url = f"{srv['url']}api/sessions{qry_str}"
         # Use a timeout in case this is a stale entry.
         with urllib.request.urlopen(url, timeout=0.5) as req:


### PR DESCRIPTION
Hi! This fixes the obvious bug with `qry_str` is not defined in _get_sessions function while using JupyterHub.

Without this fix I can't get ipynbname.name() or ipynbname.path().